### PR TITLE
Updates so ARM is compatible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,15 +3,15 @@ version: '3.4'
 services:
 
   aiinferencer:
-      image: ${DOCKER_REGISTRY-}aiinferencer:1.5
-      build:
-        context: src/Services/Detections
-        dockerfile: ai_inferencer/Dockerfile 
-      depends_on: 
-        - alertsapi-dapr
-        - files-management
-      environment:    
-        - DAPR_HTTP_PORT=3600
+    image: ${DOCKER_REGISTRY-}aiinferencer:1.5
+    build:
+      context: src/Services/Detections
+      dockerfile: ai_inferencer/Dockerfile
+    depends_on: 
+      - alertsapi-dapr
+      - files-management
+    environment:    
+      - DAPR_HTTP_PORT=3600
         
   aiinferencer-dapr:
     image: "daprio/daprd:latest"
@@ -34,13 +34,13 @@ services:
     network_mode: "service:rulesengine"
 
   framesplitter:
-      image: ${DOCKER_REGISTRY-}framesplitter:1.5
-      build:
-        context: src/Services/Detections
-        dockerfile: frameSplitter/Dockerfile
-      depends_on:
-        - aiinferencer-dapr
-        - files-management
+    image: ${DOCKER_REGISTRY-}framesplitter:1.5
+    build:
+      context: src/Services/Detections
+      dockerfile: frameSplitter/Dockerfile
+    depends_on:
+      - aiinferencer-dapr
+      - files-management
 
   framesplitter-dapr:
     image: "daprio/daprd:latest"

--- a/src/Services/Alerts/API/Dockerfile
+++ b/src/Services/Alerts/API/Dockerfile
@@ -1,8 +1,8 @@
-# Usar una plataforma específica para el proceso de construcción
+# Use a specific platform for building the image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0.400 AS build
 
-# Definir la arquitectura objetivo como un argumento con un valor por defecto de "amd64"
-ARG TARGETARCH=amd64
+# Define the target architecture as argument. By default it's amd64
+ARG TARGETARCH
 
 WORKDIR /src
 COPY ["src/Services/Alerts/API/Alerts.API.csproj", "src/Services/Alerts/API/"]

--- a/src/Services/Alerts/RulesEngine/Dockerfile
+++ b/src/Services/Alerts/RulesEngine/Dockerfile
@@ -1,8 +1,8 @@
-# Usar una plataforma específica para el proceso de construcción
+# Use a specific platform for building the image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0.400 AS build
 
-# Definir la arquitectura objetivo como un argumento con un valor por defecto de "amd64"
-ARG TARGETARCH=amd64
+# Define the target architecture as argument. By default it's amd64
+ARG TARGETARCH
 
 WORKDIR /src
 COPY ["src/Services/Alerts/RulesEngine/Alerts.RulesEngine.csproj", "src/Services/Alerts/RulesEngine/"]

--- a/src/Services/Detections/ai_inferencer/Dockerfile
+++ b/src/Services/Detections/ai_inferencer/Dockerfile
@@ -1,8 +1,14 @@
 FROM python:3.8.16-slim-bullseye
 
 COPY ai_inferencer/requirements.txt .
-RUN pip3 install --upgrade pip
-RUN pip3 install torch==1.13.1+cpu torchvision==0.14.1+cpu --extra-index-url https://download.pytorch.org/whl/cpu
+
+# Add the system packages required for psutil
+RUN apt-get update && apt-get install -y gcc python3-dev
+
+# Upgrade pip and setuptools
+RUN pip3 install --upgrade pip setuptools
+
+RUN pip3 install torch==1.13.1 torchvision==0.14.1 --extra-index-url https://download.pytorch.org/whl/cpu
 RUN pip3 install -r requirements.txt
 RUN pip3 uninstall opencv-python opencv-python-headless -y
 RUN pip3 install opencv-python-headless

--- a/src/Services/Files/Management/Dockerfile
+++ b/src/Services/Files/Management/Dockerfile
@@ -1,8 +1,8 @@
-# Indicar la plataforma para el proceso de construcción
+# Use a specific platform for building the image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0.400 AS build
 
-# Definir la arquitectura objetivo con un valor por defecto de "amd64"
-ARG TARGETARCH=amd64
+# Define the target architecture as argument. By default it's amd64
+ARG TARGETARCH
 
 WORKDIR /src
 COPY ["src/Services/Files/Management/Files.Management.csproj", "src/Services/Files/Management/"]

--- a/src/Web/alerts-ui/Dockerfile
+++ b/src/Web/alerts-ui/Dockerfile
@@ -1,8 +1,8 @@
-# Indicar la plataforma para el proceso de construcción
+# Use a specific platform for building the image
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:7.0.400 AS build
 
-# Definir la arquitectura objetivo con un valor por defecto de "amd64"
-ARG TARGETARCH=amd64
+# Define the target architecture as argument. By default it's amd64
+ARG TARGETARCH
 
 WORKDIR /src
 COPY ["src/Web/alerts-ui/Alerts.UI.csproj", "src/Web/alerts-ui/"]


### PR DESCRIPTION
- Update in ai-inferencer images so packages installed are ARM compatible.
- Removed by default amd64 architecture since it's not needed, so it takes the current architecture where you are building.